### PR TITLE
fix: correct regex for hexinteger

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -281,7 +281,7 @@ module.exports = grammar({
 		),
 
 		integer: $ => /\d+/,
-		hexinteger: $ => /0x(\\d|[a-f]|[A-F])+/,
+		hexinteger: $ => /0x([a-fA-F\d])+/,
 		float: $ => /\d+\.\d+/,
 		exponential: $ => /-?\d+(\.\d+)?[eE]-?\d+/,
 		symbol: $ => choice(


### PR DESCRIPTION
Hi, thank you for developing the tree-sitter parser for supercollider!

It looks like we should use `\d` instead of `\\d` for the digit character. This should fix #46.