### PR TITLE
fix: add highlights query path

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
       "file-types": [
         "scd",
         "sc"
-      ]
+      ],
+      "highlights": "queries/highlights.scm"
     }
   ]
 }


### PR DESCRIPTION
Without this, I got this error when running `tree-sitter highlights` command.


```
Warning: you should add a `tree-sitter-highlights` entry pointing to the highlights path in `tree-sitter` language list in the grammar's package.json
See more here: https://tree-sitter.github.io/tree-sitter/syntax-highlighting#query-paths
```