### PR TITLE
fix: duplicated_statement

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -8,6 +8,7 @@ const PRECEDENCE = {
 	call: 14,
 	field: 13,
 	unary: 15,
+    duplication: 12,
 	multiplicative: 10,
 	additive: 9,
 	shift: 8,
@@ -107,7 +108,7 @@ module.exports = grammar({
 
 		partial: $ => prec.right(PRECEDENCE.partial, "_"),
 
-		duplicated_statement: $ => prec.left(1, seq(
+		duplicated_statement: $ => prec.left(PRECEDENCE.duplication, seq(
             field("duplicated_object", $._object),
             field("operator","!"),
             field("duplication_times", $._object)

--- a/grammar.js
+++ b/grammar.js
@@ -81,7 +81,7 @@ module.exports = grammar({
 			$._object,
 			$.variable_definition,
 			$.variable_definition_sequence,
-			$.duplicated_statement,
+			// $.duplicated_statement,
 			// $.binary_expression,
 			$.return_statement
 		),
@@ -101,16 +101,17 @@ module.exports = grammar({
 			$.unary_expression,
 			$.collection,
 			$.indexed_collection,
-			$.partial
+			$.partial,
+			$.duplicated_statement,
 		),
 
 		partial: $ => prec.right(PRECEDENCE.partial, "_"),
 
-		duplicated_statement: $ => seq(
-			field("duplicated_object", $._object),
-			field("operator","!"),
-			field("duplication_times", $._object)
-		),
+		duplicated_statement: $ => prec.left(1, seq(
+            field("duplicated_object", $._object),
+            field("operator","!"),
+            field("duplication_times", $._object)
+        )),
 
 		/////////////////
 		//  Functions  //

--- a/test/corpus/weirdstuff.txt
+++ b/test/corpus/weirdstuff.txt
@@ -41,7 +41,7 @@ Chained duplications
           (integer))))))
 
 ====================
-Assign duplication statement to local variable
+Assign duplication to local variable
 ====================
 
 (
@@ -69,7 +69,7 @@ train = "choo" ! 2;
 
 
 ====================
-duplicated argument
+duplication as function call argument
 ====================
 
 { PinkNoise.ar(0.1!2) };
@@ -93,6 +93,30 @@ duplicated argument
                 duplication_times: (literal
                   (number
                     (integer)))))))))))
+
+====================
+Math on duplications
+====================
+
+(
+1 ! 2 + 3;
+)
+
+---
+
+(source_file
+  (code_block
+    (binary_expression
+      left: (duplicated_statement
+        duplicated_object: (literal
+          (number
+            (integer)))
+        duplication_times: (literal
+          (number
+            (integer))))
+      right: (literal
+        (number
+          (integer))))))
 
 ====================
 partial: [a, b, _]

--- a/test/corpus/weirdstuff.txt
+++ b/test/corpus/weirdstuff.txt
@@ -18,6 +18,83 @@ Basic duplication
           (hexinteger ))))))
 
 ====================
+Chained duplications
+====================
+
+(
+1!2!3
+)
+
+---
+(source_file
+  (code_block
+    (duplicated_statement
+      duplicated_object: (duplicated_statement
+        duplicated_object: (literal
+          (number
+            (integer)))
+        duplication_times: (literal
+          (number
+            (integer))))
+      duplication_times: (literal
+        (number
+          (integer))))))
+
+====================
+Assign duplication statement to local variable
+====================
+
+(
+var train;
+train = "choo" ! 2;
+)
+
+---
+
+(source_file
+  (code_block
+    (variable
+      (local_var
+        name: (identifier)))
+    (variable_definition
+      name: (variable
+        (local_var
+          name: (identifier)))
+      value: (duplicated_statement
+        duplicated_object: (literal
+          (string))
+        duplication_times: (literal
+          (number
+            (integer)))))))
+
+
+====================
+duplicated argument
+====================
+
+{ PinkNoise.ar(0.1!2) };
+
+---
+
+(source_file
+  (function_block
+    (function_call
+      (receiver
+        (class))
+      (method_call
+        name: (method_name)
+        (parameter_call_list
+          (argument_calls
+            (unnamed_argument
+              (duplicated_statement
+                duplicated_object: (literal
+                  (number
+                    (float)))
+                duplication_times: (literal
+                  (number
+                    (integer)))))))))))
+
+====================
 partial: [a, b, _]
 ====================
 (


### PR DESCRIPTION
duplicated statements were not parsing correctly in some cases (variable assignments, function call arguments, chaining them), putting them in `_object` definition with left precedence seems to do the trick, but maybe i overlooked something ?