### PR TITLE
Fixes #42

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -309,14 +309,15 @@ module.exports = grammar({
 		char: $ => /\$./,
 
 		// Taken from https://github.com/tree-sitter/tree-sitter-javascript/blob/83f6a2d900a2dc245e4717ccd05c2a362443cd87/grammar.js#L808
-		string: $ =>
-		seq(
-			'"',
-			repeat(choice(
-				token.immediate(prec(PRECEDENCE.STRING, /[^"\\\n]+|\\\r?\n/)),
-				$.escape_sequence
-			)),
-			'"'
+		string: $ => repeat1(
+            seq(
+                '"',
+                repeat(choice(
+                    token.immediate(prec(PRECEDENCE.STRING, /[^"\\\n]+|\\\r?\n/)),
+                    $.escape_sequence
+                )),
+                '"'
+            )
 		),
 
 		bool: $ => choice("true", "false"),

--- a/grammar.js
+++ b/grammar.js
@@ -234,13 +234,18 @@ module.exports = grammar({
 			seq(
                 'arg',
                 sepBy(',', $.argument),
-                optional(seq("...", $.argument)),
+                // optional(seq("...", $.argument)),
+                optional(alias($.variable_argument, $.argument)),
                 ';'
             ),
 			seq(
                 '|',
-                sepBy(choice($._space_separator, ','), $.argument),
-                optional(seq("...", $.argument)),
+                sepBy(choice($._space_separator, ','),
+                    choice(
+                        $.argument,
+                        alias($.variable_argument, $.argument),
+                    ),
+                ),
                 '|'
             )
 		),
@@ -256,6 +261,9 @@ module.exports = grammar({
                 )
             ))
 		),
+
+        // see https://doc.sccode.org/Reference/Functions.html#Variable%20Arguments
+        variable_argument: $ => seq("...", field("name", $.identifier)),
 
 		// When supplying arguments to a function call
 		parameter_call_list: $ => sepBy1(',', $.argument_calls),

--- a/grammar.js
+++ b/grammar.js
@@ -46,6 +46,7 @@ module.exports = grammar({
 
 	externals: $ => [
 		$.block_comment,
+        $._space_separator
 	],
 
 	//inline: $ => [$.keywords],
@@ -230,14 +231,29 @@ module.exports = grammar({
 
 		// Definition of parameters in function
 		parameter_list: $ => choice(
-			seq('arg', sepBy(',', $.argument), optional(seq("...", $.argument)), ';'),
-			seq('|', sepBy(choice(' ', ','), $.argument), optional(seq("...", $.argument)), '|')
+			seq(
+                'arg',
+                sepBy(',', $.argument),
+                optional(seq("...", $.argument)),
+                ';'
+            ),
+			seq(
+                '|',
+                sepBy(choice($._space_separator, ','), $.argument),
+                optional(seq("...", $.argument)),
+                '|'
+            )
 		),
 
 		// For definition lists
 		argument: $ => seq(
 			field("name", $.identifier),
-			field("value", optional(choice(seq("=", choice($.literal, $.collection)), seq("(", $.literal, ")"))))
+            field("value", optional(
+                choice(
+                    seq("=", choice($.literal, $.collection)),
+                    seq("(", $.literal, ")")
+                )
+            ))
 		),
 
 		// When supplying arguments to a function call

--- a/grammar.js
+++ b/grammar.js
@@ -250,8 +250,9 @@ module.exports = grammar({
 			field("name", $.identifier),
             field("value", optional(
                 choice(
-                    seq("=", choice($.literal, $.collection)),
-                    seq("(", $.literal, ")")
+                    seq("=", choice($.literal, $.collection, $.code_block)),
+                    $.code_block,
+                    // seq("(", $.literal, ")")
                 )
             ))
 		),

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,4 +1,4 @@
-#include <tree_sitter/parser.h>
+#include "tree_sitter/parser.h"
 #include <wctype.h>
 // Block comment stuff here is largely nicked from tree-sitter-rust https://github.com/tree-sitter/tree-sitter-rust
 

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -19,12 +19,13 @@ static void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
 static bool is_num_char(int32_t c) { return c == '_' || iswdigit(c); }
 
 bool tree_sitter_supercollider_external_scanner_scan(
-    void *payload, TSLexer *lexer, const bool *valid_symbols) {
+  void *payload, TSLexer *lexer, const bool *valid_symbols) {
 
+  // space as separator in '{ |arg1 arg2| }' style argument declaration
   if (valid_symbols[SPACE_SEPARATOR] && iswspace(lexer->lookahead)) {
     while (iswspace(lexer->lookahead))
       lexer->advance(lexer, true);
-    if (lexer->lookahead != '=') {
+    if (lexer->lookahead != '=' && lexer->lookahead != '|') {
       lexer->result_symbol = SPACE_SEPARATOR;
       return true;
     }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -2,7 +2,11 @@
 #include <wctype.h>
 // Block comment stuff here is largely nicked from tree-sitter-rust https://github.com/tree-sitter/tree-sitter-rust
 
-enum TokenType { BLOCK_COMMENT, STRING };
+enum TokenType { 
+  BLOCK_COMMENT,
+  // STRING,
+  SPACE_SEPARATOR
+};
 
 void *tree_sitter_supercollider_external_scanner_create() { return NULL; }
 void tree_sitter_supercollider_external_scanner_destroy(void *p) {}
@@ -16,6 +20,15 @@ static bool is_num_char(int32_t c) { return c == '_' || iswdigit(c); }
 
 bool tree_sitter_supercollider_external_scanner_scan(
     void *payload, TSLexer *lexer, const bool *valid_symbols) {
+
+  if (valid_symbols[SPACE_SEPARATOR] && iswspace(lexer->lookahead)) {
+    while (iswspace(lexer->lookahead))
+      lexer->advance(lexer, true);
+    if (lexer->lookahead != '=') {
+      lexer->result_symbol = SPACE_SEPARATOR;
+      return true;
+    }
+  }
 
   while (iswspace(lexer->lookahead))
     lexer->advance(lexer, true);

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -185,6 +185,28 @@ Argument list with no commas
           name: (identifier ))))))
 
 =====================
+Spaces in argument list with no commas
+=====================
+
+(
+{|argument1 = \arg1 argument2|}
+)
+
+---
+
+(source_file
+  (code_block
+    (function_block
+      (parameter_list
+        (argument
+          name: (identifier)
+          value: (literal
+            (symbol
+              (identifier))))
+        (argument
+          name: (identifier))))))
+
+=====================
 function call in associtive item
 =====================
 (

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -1,10 +1,13 @@
 ====
 C-style initialization of arguments using parenthesis
 ====
+
 NiceNice{
   *new{|aNumber(10)|}
 }
+
 ---
+
 (source_file
   (class_def
     (class )
@@ -13,9 +16,11 @@ NiceNice{
       (parameter_list
         (argument
           name: (identifier )
-          value: (literal
-            (number
-              (integer ))))))))
+          value: (code_block 
+            (literal
+              (number
+                (integer)))))))))
+
 ====================
 selector as infix binary operators
 ====================

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -194,7 +194,7 @@ Spaces in argument list with no commas
 =====================
 
 (
-{|argument1 = \arg1 argument2|}
+{ | argument1 = \arg1 argument2 | }
 )
 
 ---
@@ -208,6 +208,27 @@ Spaces in argument list with no commas
           value: (literal
             (symbol
               (identifier))))
+        (argument
+          name: (identifier))))))
+
+=====================
+Argument list with variable argument
+=====================
+
+(
+{ | arg0, arg1 ...rest | };
+)
+
+---
+
+(source_file
+  (code_block
+    (function_block
+      (parameter_list
+        (argument
+          name: (identifier))
+        (argument
+          name: (identifier))
         (argument
           name: (identifier))))))
 


### PR DESCRIPTION
This is an attempt to fix #42 by implementing the solution proposed [here](https://github.com/tree-sitter/tree-sitter/discussions/1633).
Essentially we define an external token `_space_separator` that is used in `parameter_list` definition. 
The scanner looks for white-spaces and returns the token only if it does not encounter the `=` character, allowing spaces to act as separators while preserving normal space behavior around assignments.

I added another test to check this behavior.

