### PR TITLE
Fix: method-call and flatten binary operators precedence, Add: List Comprehension

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -376,18 +376,25 @@ module.exports = grammar({
 			$.char,
 			$.string,
 			$.bool,
-			// $.pi_statement
 		),
 
-		// pi_statement: $ => seq(optional($.number), "pi"),
+		/**
+		 * number
+		 * ------
+		 * Numeric literals supported by SuperCollider.
+		 *
+		 *
+		 * Note: Special handling of `pi` was removed; it should be treated
+		 * as a constant or symbol rather than a literal number.
+		 */
 		number: $ => choice(
 			$.integer,
 			$.float,
 			$.hexinteger,
-			$.exponential,
-			"pi",
-			seq(optional($.number), "pi")
+			$.exponential
 		),
+
+		// pi_statement: $ => seq(optional($.number), "pi"),
 
 		integer: $ => /\d+/,
 		hexinteger: $ => /0x([a-fA-F\d])+/,

--- a/grammar.js
+++ b/grammar.js
@@ -671,13 +671,6 @@ module.exports = grammar({
 		///////////////////
 		//	Expressions  //
 		///////////////////
-		// "Selector as binary operator"
-		// selector_binary: $ => prec(PRECEDENCE.selectorBinary, prec.left(seq(
-		//	field('left', $._object),
-		//	field('operator', prec.right(seq($.identifier, ":"))),
-		//	field('right', $._object)
-		// ))),
-
 
 		/**
 		 * binary_expression

--- a/grammar.js
+++ b/grammar.js
@@ -64,36 +64,51 @@ module.exports = grammar({
 			seq($._expression_statement, ";"),
 		),
 
-		_expression_statement: $ => choice(
-			$.function_definition,
-			$.function_call,
-			$.binary_expression,
-			$.unary_expression,
-			//$.keyword_message,
-			$._postfix,
-			$.variable_definition,
-			$.variable_definition_sequence,
-			$.return_statement
-		),
 
-		// These are the values that may be assigned to a variable or argument
+		/**
+		 * _object
+		 * -------
+		 * Any expression that can be used as a value in sclang
+		 * (i.e. anything that produces or holds a value).
+		 *
+		 * Essentially all expressions except statement-specific forms
+		 */
 		_object: $ => choice(
-			prec(2, $.class),
-			$.association,
-			$.nil_conditional,
-			$.nil_guard,
-			$.nil_default,
+			prec(2, $.class),          // Class references (higher precedence)
+			$.association,             // Key->value pairs
+			$.nil_conditional,         // x ? y or x ? {...} {...}
+			$.nil_guard,               // x !? {...}
+			$.nil_default,             // x ?? defaultValue
 			$.code_block,
 			$.function_block,
 			$.control_structure,
-			$.literal,
-			$.variable,
-			$.binary_expression,
-			$.unary_expression,
+			$.literal,                 // Numbers, strings, symbols, etc.
+			$.variable,                // Variable references
+			$.binary_expression,       // a + b, a collect: b, etc.
+			$.unary_expression,        // -x, +x
+			$.function_call,
+			$._postfix,
 			$.collection,
 			$.indexed_collection,
 			$.partial,
-			$.duplicated_statement,
+			$.duplicated_statement
+		),
+
+		/**
+		 * _expression_statement
+		 * ---------------------
+		 * Any construct that can stand alone as a statement in sclang.
+		 * This includes:
+		 *   - Statement-specific forms (definitions, returns)
+		 *   - Any expression (_object)
+		 *
+		 */
+		_expression_statement: $ => choice(
+			$.function_definition,         // f = { ... }
+			$.variable_definition,         // x = value
+			$.variable_definition_sequence, // x = 1, y = 2
+			$.return_statement,            // ^value
+			$._object                      // Any expression can be a statement
 		),
 
 		partial: $ => prec.right(PRECEDENCE.partial, "_"),

--- a/grammar.js
+++ b/grammar.js
@@ -97,7 +97,6 @@ module.exports = grammar({
 		// These are the values that may be assigned to a variable or argument
 		_object: $ => choice(
 			prec(2, $.class),
-			prec(20, $.function_call),
 			$.association,
 			$.nil_check,
 			$.code_block,
@@ -360,7 +359,7 @@ module.exports = grammar({
 		 *   Env.perc(0.01, curve: -1)
 		 */
 		parameter_call_list: $ => sepBy1(',', choice($.named_argument, $._object)),
-		
+
 		named_argument: $ => seq(
 		  field('name',  choice($.symbol, $.identifier)),
 		  ':',

--- a/grammar.js
+++ b/grammar.js
@@ -187,14 +187,14 @@ module.exports = grammar({
 		 *   - The `name` is captured as `method_name` for highlighting/queries.
 		 *   - Arguments are optional:
 		 *       • `()` with optional parameter list
-		 *       • or an inline function block used as an argument
+		 *       • or an inline code block used as an argument
 		 */
 		method_call: $ => seq(
 			".",
 			field("name", alias($.identifier, $.method_name)),
 			optional(choice(
 				seq("(", optional($.parameter_call_list), ")"),
-				$._function_content
+				$.code_block
 			))
 		),
 
@@ -707,10 +707,10 @@ module.exports = grammar({
 		 *   \freq.kr(440) * (Env.perc(0.01, curve: -1).ar * 48).midiratio
 		 */
 		binary_expression: $ => prec.left(PRECEDENCE.BIN, seq(
-			field('left',  $._postfix),
+			field('left', $._postfix),
 			field('operator', choice(
-				'||','&&','|','^','&','==','!=','<','<=','>','>=',
-				'<<','>>','+','-','++','+/+','*','/','%','**',
+				'||', '&&', '|', '^', '&', '==', '!=', '<', '<=', '>', '>=',
+				'<<', '>>', '+', '-', '++', '+/+', '*', '/', '%', '**',
 				/[A-Za-z_]\w*:/
 			)),
 			field('right', $._postfix)

--- a/grammar.js
+++ b/grammar.js
@@ -480,7 +480,7 @@ module.exports = grammar({
 		variable_definition: $ => prec(PRECEDENCE.vardef, seq(
 			field("name", $.variable),
 			"=",
-			field("value", choice($.class, $._object, $.function_call))
+			field("value", $._object)
 		)),
 
 		///////////////

--- a/grammar.js
+++ b/grammar.js
@@ -72,6 +72,7 @@ module.exports = grammar({
 
 		_expression: $ => choice(
 			$.code_block,
+			$.group,
 			$.class_def,
 			seq($._expression_statement, ";"),
 		),
@@ -199,36 +200,49 @@ module.exports = grammar({
 			optional(";")
 		),
 
+		// { ... } (code block)
 		code_block: $ => seq(
-			'(',
+			'{',
+			optional($.parameter_list),
 			optional($._expression_sequence),
-			')'
+			'}'
 		),
+
+		// ( ... ) (parenthesized expression / grouping)
+		group: $ => seq('(', $._expression, ')'),
 
 		function_block: $ => choice(
 			$._function_content,
 			prec.left(seq(alias($.identifier, $.method_name), $._function_content)),
 		),
 
-		_function_content: $ => choice(
-			seq(
-				'{',
-				optional($.parameter_list),
-				// optional(seq($._expression_statement, ";")),
-				optional(
-					$._expression_sequence
-				),
-				'}'
-			),
-			seq(
-				seq("(", "{"),
-				optional($.parameter_list),
-				optional(
-					$._expression_sequence
-				),
-				seq(")", "}"),
-			),
+		// _function_content: $ => choice(
+		// 	seq(
+		// 		'{',
+		// 		optional($.parameter_list),
+		// 		// optional(seq($._expression_statement, ";")),
+		// 		optional(
+		// 			$._expression_sequence
+		// 		),
+		// 		'}'
+		// 	),
+		// 	seq(
+		// 		seq("(", "{"),
+		// 		optional($.parameter_list),
+		// 		optional(
+		// 			$._expression_sequence
+		// 		),
+		// 		seq(")", "}"),
+		// 	),
+		// ),
+
+		_function_content: $ => seq(
+			'{',
+			optional($.parameter_list),
+			optional($._expression_sequence),
+			'}'
 		),
+		
 
 		// Definition of parameters in function
 		parameter_list: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -1,3 +1,4 @@
+
 const PRECEDENCE = {
   comment: 1000,
 
@@ -34,7 +35,7 @@ module.exports = grammar({
   // ---------- Metadata / Tokens ----------
   word: $ => $.identifier,
   extras: $ => [/\s/, $.line_comment, $.block_comment],
-  externals: $ => [ $.block_comment, $._space_separator ],
+  externals: $ => [$.block_comment, $._space_separator],
 
   // Optional supertypes (useful for queries)
   // supertypes: $ => [ $._expression, $._object, $._primary ],
@@ -187,6 +188,22 @@ module.exports = grammar({
     hexinteger: $ => /0x([a-fA-F\d])+/,
     float: $ => /\d+\.\d+/,
     exponential: $ => /-?\d+(\.\d+)?[eE]-?\d+/,
+
+    pi_literal: $ => choice(
+      'pi',                          // π
+      seq(choice($.integer, $.float), 'pi') // 2pi, 2.5pi
+    ),
+
+    accidental: $ => /\d+[sb]+/,    // e.g. 12s, 4bb, 7ss
+
+    number: $ => choice(
+      $.integer,
+      $.float,
+      $.hexinteger,
+      $.exponential,
+      $.pi_literal,
+      $.accidental
+    ),
 
     symbol: $ => choice(
       prec.left(seq('\\', optional(choice($.identifier, /[0-9]+/, $.escape_sequence)))),

--- a/grammar.js
+++ b/grammar.js
@@ -1,836 +1,488 @@
 const PRECEDENCE = {
-	comment: 1000,
-	call: 140,            // chains bind tighter than any binary op
-	BIN: 20,              // flat, left-associative binary tier
-	unary: 130,           // unary binds tighter than BIN (but below call)
-	keyword_message: 19,  // below BIN for left-to-right evaluation
-	association: 11,
-	associative_item: 10,
-	STRING: 2,
-	partial: 15,
-	field: 13,
-	duplication: 12,
-	assign: 0,
-	controlstruct: 3,
-	localvar: 4,
-	vardef: 3,
-	vardef_sequence: 2,
-	closure: -1,
-	class_def: 1,
-	class: 20
-}
+  comment: 1000,
 
-function sepBy1(sep, rule) { return seq(rule, repeat(seq(sep, rule)))}
-function sepBy(sep, rule) { return optional(sepBy1(sep, rule))}
+  // expression tiers
+  call: 140,           // postfix chains bind tighter than any binary op
+  unary: 130,          // tighter than BIN, looser than call
+  BIN: 20,             // flat, left-associative binary tier
+  keyword_message: 19, // below BIN to preserve L→R evaluation
+
+  // misc
+  association: 11,
+  associative_item: 10,
+  partial: 15,
+  field: 13,
+  duplication: 12,
+  controlstruct: 3,
+  localvar: 4,
+  vardef: 3,
+  vardef_sequence: 2,
+  assign: 0,
+  STRING: 2,
+  closure: -1,
+  class_def: 1,
+  class: 20
+};
+
+// Small combinators
+function sepBy1(sep, rule) { return seq(rule, repeat(seq(sep, rule))); }
+function sepBy(sep, rule) { return optional(sepBy1(sep, rule)); }
 
 module.exports = grammar({
-	name: 'supercollider',
-	extras: $ => [/\s/, $.line_comment, $.block_comment],
-	externals: $ => [ $.block_comment, $._space_separator],
-	inline: $ => [$.bin_op],
-	word: $ => $.identifier,
-	conflicts: $ => [
-		[$.switch],
-		[$._expression, $._object],
-		[$._primary, $.function_block],
-		[$._primary, $.collection],
-	],
-
-	rules: {
-		source_file: $ => repeat($._expression),
-
-		_expression: $ => choice(
-			$.class_def,
-			seq($._expression_statement, ";"),
-		),
-
-		_expression_statement: $ => choice(
-			$.function_definition,
-			$.function_call,
-			$.binary_expression,
-			$.unary_expression,
-			$.keyword_message,
-			$._postfix,
-			$.variable_definition,
-			$.variable_definition_sequence,
-			$.return_statement
-		),
-
-		_object: $ => choice(
-			$.association,
-			$.nil_conditional,
-			$.nil_guard,
-			$.nil_default,
-			$.function_block,
-			$.control_structure,
-			$.binary_expression,
-			$.unary_expression,
-			$.indexed_collection,
-			$.partial,
-			$.duplicated_statement,
-			$.keyword_message,
-			$._postfix
-		),
-
-		partial: $ => prec.right(PRECEDENCE.partial, "_"),
-
-		duplicated_statement: $ => prec.left(PRECEDENCE.duplication, seq(
-			field("duplicated_object", $._object),
-			field("operator", "!"),
-			field("duplication_times", $._object)
-		)),
-
-		function_definition: $ => prec.left(1, seq(
-			field("name", $.variable),
-			'=',
-			field("value", $.function_block)
-		)),
-
-		function_call: $ => seq(
-			choice(alias($.identifier, $.method_name), $.class),
-			"(", optional($.parameter_call_list), ")"
-		),
-
-		/**
-		 * _primary
-		 * ----------
-		 * Defines a *primary expression* — the basic building blocks that can
-		 * stand alone or serve as receivers for method calls.
-		 *
-		 */
-		_primary: $ => choice(
-			$.literal,
-			$.variable,
-			$.class,
-			$.collection,
-			$.list_comprehension,
-			$.code_block,
-			$.group
-		),
-
-		method_call: $ => prec.right(seq(
-			".",
-			field("name", alias($.identifier, $.method_name)),
-			optional(choice(
-				seq("(", optional($.parameter_call_list), ")"),
-				$.code_block
-			))
-		)),
-
-		/**
-		 * _postfix
-		 * ---------
-		 * A postfix expression: either a bare primary or a chain of calls.
-		 *
-		 * Variants:
-		 *   - `<primary>.<method>(...)...` — one primary followed by ≥1 method calls
-		 *   - `<primary>` — a bare primary
-		 *
-		 */
-		_postfix: $ => choice(
-			prec.left(PRECEDENCE.call, seq(
-				$._primary,
-				repeat1($.method_call)
-			)),
-			$._primary
-		),
-
-		// This is unused
-		instance_variable_setter_call: $ => prec.left(2,
-			seq(
-				".",
-				field("name", alias($.identifier, $.method_name)),
-				"_",
-				// Instance.method or Instance.method()
-				optional(seq("(", optional($.parameter_call_list), ")")),
-
-			)
-		),
-
-		_expression_sequence: $ => seq(
-			repeat(prec.right(1, seq($._expression_statement, ";"))),
-			// Last statement in sequence
-			$._expression_statement,
-			optional(";")
-		),
-
-		code_block: $ => seq(
-			'{',
-			optional($.parameter_list),
-			optional($._expression_sequence),
-			'}'
-		),
-
-		/**
-		 * group
-		 * -----
-			 * A parenthesized expression for grouping. It can contain any expression,
-		 * including a code block node; evaluation semantics are unchanged.
-		 * 
-		 * Examples:
-		 *   (2 + 3)           // Simple grouping
-		 *   ({ "hello" })     // Immediate code block evaluation
-		 */
-		group: $ => seq(
-			'(',
-			$._expression_sequence,
-			')'
-		),
-
-		/**
-		 * function_block
-		 * --------------
-		 * Either a plain code block or one prefixed with a method name.
-		 * The method name version is for special syntactic sugar.
-		 */
-		function_block: $ => choice(
-			$.code_block,
-			prec.left(seq(alias($.identifier, $.method_name), $.code_block))
-		),
-
-		// Definition of parameters in function
-		parameter_list: $ => choice(
-			seq(
-				'arg',
-				sepBy(',', $.argument),
-				// optional(seq("...", $.argument)),
-				optional(alias($.variable_argument, $.argument)),
-				';'
-			),
-			seq(
-				'|',
-				sepBy(choice($._space_separator, ','),
-					choice(
-						$.argument,
-						alias($.variable_argument, $.argument),
-					),
-				),
-				'|'
-			)
-		),
-
-		// For definition lists
-		argument: $ => seq(
-			field("name", $.identifier),
-			field("value", optional(
-				choice(
-					seq("=", choice($.literal, $.collection, $.code_block)),
-					$.code_block,
-					// seq("(", $.literal, ")")
-				)
-			))
-		),
-
-		// see https://doc.sccode.org/Reference/Functions.html#Variable%20Arguments
-		variable_argument: $ => seq("...", field("name", $.identifier)),
-
-		parameter_call_list: $ => sepBy1(',', choice($.named_argument, $._object)),
-
-		named_argument: $ => seq(
-			field('name', choice($.symbol, $.identifier)),
-			':',
-			field('value', $._object)
-		),
-
-		///////////////////////
-		//	Define literal	//
-		///////////////////////
-
-		literal: $ => choice(
-			$.number,
-			$.symbol,
-			$.char,
-			$.string,
-			$.bool,
-		),
-
-		number: $ => choice(
-			$.integer,
-			$.float,
-			$.hexinteger,
-			$.exponential
-		),
-
-		integer: $ => /\d+/,
-		hexinteger: $ => /0x([a-fA-F\d])+/,
-		float: $ => /\d+\.\d+/,
-		exponential: $ => /-?\d+(\.\d+)?[eE]-?\d+/,
-		symbol: $ => choice(
-			prec.left(seq('\\', optional(choice($.identifier, /[0-9]+/, $.escape_sequence)))),
-			prec.left(seq("'", optional(token.immediate(/[^"'\\]+/)), "'")),
-		),
-		char: $ => /\$./,
-
-		// Taken from https://github.com/tree-sitter/tree-sitter-javascript/blob/83f6a2d900a2dc245e4717ccd05c2a362443cd87/grammar.js#L808
-		string: $ => repeat1(
-			seq(
-				'"',
-				repeat(choice(
-					token.immediate(prec(PRECEDENCE.STRING, /[^"\\\n]+|\\\r?\n/)),
-					$.escape_sequence
-				)),
-				'"'
-			)
-		),
-
-		bool: $ => choice("true", "false"),
-
-		// TODO: Is this necessary in SC?
-		escape_sequence: $ => token.immediate(seq(
-			'\\',
-			choice(
-				/[^xu0-7]/,
-				/[0-7]{1,3}/,
-				/x[0-9a-fA-F]{2}/,
-				/u[0-9a-fA-F]{4}/,
-				/u\{[0-9a-fA-F]+\}/
-			)
-		)),
-
-		/////////////////
-		//	Variables  //
-		/////////////////
-
-		variable: $ => choice(
-			$.environment_var,
-			$.classvar,
-			$.builtin_var,
-			$.instance_var
-		),
-
-		builtin_var: $ => field("name", choice(
-			"inf",
-			"nil",
-			"thisFunction",
-			"thisFunctionDef",
-			"thisMethod",
-			"thisProcess",
-			"thisThread",
-			"currentEnvironment",
-			"topEnvironment"
-		)),
-
-		local_var: $ => prec(PRECEDENCE.localvar,
-			seq('var', field("name", $.identifier))
-
-		),
-
-		instance_var: $ => seq(optional('var'), optional(choice("<", ">", "<>")), field("name", $.identifier)),
-		classvar: $ => seq('classvar', optional(choice("<", ">", "<>")), field("name", $.identifier)),
-		const: $ => seq('const', optional(choice("<", ">", "<>")), field("name", $.identifier)),
-
-		environment_var: $ => choice(
-			field("name", alias(/[a-z]/, $.identifier)),
-			field("name", alias(seq('~', $.identifier), $.identifier)),
-		),
-
-		variable_name: $ => $.identifier,
-
-		variable_definition: $ => prec(PRECEDENCE.vardef, seq(
-			field("name", $.variable),
-			"=",
-			field("value", $._object)
-		)),
-
-		variable_definition_sequence: $ => prec(PRECEDENCE.vardef_sequence,
-			seq(
-				sepBy(",", choice($.variable_definition, $.variable)),
-				",", choice($.variable_definition, $.variable)
-			)
-		),
-
-		///////////////
-		//	Classes  //
-		///////////////
-
-		return_statement: $ => prec.left(seq("^", choice($._object, $.function_call))),
-
-		class_def: $ => prec(PRECEDENCE.class_def, seq(optional("+"), $.class, optional(seq(":", alias($.class, $.parent_class))), "{",
-			repeat(
-				choice(
-					// Variables
-					seq(
-						sepBy(",",
-							choice(
-								// Variable declaration
-								choice(
-									alias($.local_var, $.instance_var),
-									$.instance_var,
-									$.classvar
-								),
-								// Variable definition
-								seq(
-									choice(
-										alias($.local_var, $.instance_var),
-										$.instance_var,
-										$.classvar,
-										$.const
-									),
-									"=",
-									$._object
-								),
-							)
-						),
-						";"
-					),
-					// Instance method
-					seq(
-						alias($.identifier, $.instance_method_name), $.function_block
-					),
-					// Class method
-					seq(
-						"*", alias($.identifier, $.class_method_name), $.function_block
-					),
-				)
-			),
-			"}")),
-
-		////////////////
-		//	Comments  //
-		////////////////
-
-		comment: $ => choice($.line_comment,$.block_comment),
-
-		line_comment: $ => prec(PRECEDENCE.comment, token(seq('//', /.*/))),
-
-		///////////////////
-		//	Collections  //
-		///////////////////
-
-		ref: $ => "`",
-		collection: $ => prec.left(seq(
-			// Optional class prefix
-			// The actual collection
-			choice(
-				$.arithmetic_series,
-				prec.left(seq(
-					optional(choice("#", $.ref)),
-					optional(
-						choice(
-							optional(
-								alias($.class, $.collection_type)
-							)
-						)
-					),
-					"[",
-					$._collection_sequence,
-					"]"
-				)),
-				seq(
-					"(",
-					$._paired_associative_sequence,
-					")"
-				),
-			)
-		)),
-
-		_collection_sequence: $ => seq(sepBy1(",", choice(
-			$.associative_item,
-			$._object
-		)), optional(",")),
-
-		_paired_associative_sequence: $ => seq(sepBy1(",", $.associative_item), optional(",")),
-
-		// See this link for more info
-		// https://doc.sccode.org/Reference/Key-Value-Pairs.html
-		association: $ => prec(
-			PRECEDENCE.association,
-			seq(
-				prec.left($._object),
-				prec(PRECEDENCE.assign, "->"),
-				prec.right($._object)
-			)
-		),
-
-		associative_item: $ => prec(PRECEDENCE.associative_item,
-			seq(
-				choice(
-					seq($.identifier, ":", alias($._object, $.item)),
-					$.association
-				)
-			)
-		),
-
-		// These are unused at the moment
-		_collection_types: $ => choice($._unordered_collection_types, $._ordered_collection_types),
-
-		_unordered_collection_types: $ => choice(
-			"Bag",
-			"Dictionary",
-			"Environment",
-			"Event",
-			"IdentityBag",
-			"IdentityDictionary",
-			"IdentitySet",
-			"LazyEnvir",
-			"MultiLevelIdentityDictionary",
-			"ObjectTable",
-			"Set",
-			"TwoWayIdentityDictionary"
-		),
-
-		_ordered_collection_types: $ => choice(
-			"Array",
-			"Array2D",
-			"ArrayedCollection",
-			"DoubleArray",
-			"FloatArray",
-			"Int16Array",
-			"Int32Array",
-			"Int8Array",
-			"LinkedList",
-			"List",
-			"Order",
-			"OrderedIdentitySet",
-			"Pair",
-			"PriorityQueue",
-			"RawArray",
-			"SequenceableCollection",
-			"Signal",
-			"SortedList",
-			"SparseArray",
-			"String",
-			"SymbolArray",
-		),
-
-		_indexable_object: $ => choice(
-			$._postfix,
-			prec.left(1, $.code_block),
-			$.control_structure
-		),
-
-		indexed_collection: $ => seq(
-			$._indexable_object,
-			repeat($._index),
-			$._index
-		),
-
-		index_subrange: $ => choice(
-			seq($._numeric_expression, ".."),
-			seq("..", $._numeric_expression),
-			seq($._numeric_expression, "..", $._numeric_expression),
-			seq($._numeric_expression, ",", $._numeric_expression, "..", $._numeric_expression),
-		),
-
-		_index: $ => seq(
-			"[",
-			field("index", choice($._numeric_expression, $.index_subrange)),
-			"]"
-		),
-
-
-		// Arithmetic series patterns
-		arithmetic_series: $ => seq('(', choice(
-			$.arithmetic_series_full,    // (start, step .. end)
-			$.arithmetic_series_to_end,  // (.. end)
-			$.arithmetic_series_range    // (start .. end)
-		), ')'
-		),
-
-		arithmetic_series_full: $ => seq($._postfix, ',', $._postfix, '..', $._postfix),
-		arithmetic_series_to_end: $ => seq('..', $._postfix),
-		arithmetic_series_range: $ => seq($._postfix, '..', $._postfix),
-
-		///////////////////
-		//	Expressions  //
-		///////////////////
-
-		/**
-		 * binary_expression
-		 * -----------------
-		 */
-		bin_op: $ => choice('||', '&&', '|', '^', '&', '==', '!=', '<', '<=', '>', '>=', '<<', '>>', '+', '-', '++', '+/+', '*', '/', '%', '**'),
-		binary_expression: $ => prec.left(PRECEDENCE.BIN, seq(
-			field('left', $._postfix),
-			field('operator', $.bin_op),
-			field('right', $._postfix)
-		)),
-
-		/** 
-		 * keyword_message	
-		 * ----------------
-		 * */
-		keyword_message: $ => prec.left(PRECEDENCE.keyword_message, seq(
-			field('receiver', $._postfix),
-			field('selector', alias(/[a-zA-Z_]\w*:/, $.keyword_selector)),
-			field('argument', $._postfix)
-		)),
-
-		/**
-		 * unary_expression
-		 * ----------------
-		 * Unary operators applied to a term. Unary binds tighter than BIN,
-		 * but looser than CALL (so chains still attach to the operand).
-		 * 
-		 * Note: `:` is treated as a unary operator here for simplicity,
-		 * r = (:1..10); 
-		 * -> a Routine
-		 */
-		unary_expression: $ => prec.left(PRECEDENCE.unary, seq(
-			field("operator", choice('+', '-', ':')),
-			field("right", $._postfix)
-		)),
-
-		class: $ => prec(PRECEDENCE.class, field("name", /[A-Z][a-zA-Z\d_]*/)),
-
-		//identifier: $ => /[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]*/,
-		identifier: $ => /[\p{L}_][\p{L}\p{N}_]*/u,
-
-		/**
-		 *  Nil check operators: ?, !?, ??
-		 * ------------------------
-		 * These operators have special evaluation rules
-		 * 
-		 */
-
-		// Nil-check operators with their special forms
-		nil_conditional: $ => prec.left(PRECEDENCE.BIN, choice(
-			// expr ? valueIfNotNil
-			seq(
-				field('condition', $._postfix),
-				'?',
-				field('if_not_nil', $._postfix)
-			),
-			// expr ? { blockIfNotNil } { blockIfNil }  (ternary-like)
-			seq(
-				field('condition', $._postfix),
-				'?',
-				field('if_not_nil', $.code_block),
-				field('if_nil', $.code_block)
-			)
-		)),
-
-		nil_guard: $ => prec.left(PRECEDENCE.BIN, seq(
-			// expr !? funcOrValue  (evaluates right only if left is not nil)
-			field('value', $._postfix),
-			'!?',
-			field('action', choice($._postfix, $.code_block))
-		)),
-
-		nil_default: $ => prec.left(PRECEDENCE.BIN, seq(
-			// expr ?? defaultValue  (returns right if left is nil)
-			field('value', $._postfix),
-			'??',
-			field('default', choice($._postfix, $.code_block))
-		)),
-
-		// Expressions that can hold or return a single value
-		_numeric_expression: $ => choice(
-			$._postfix,
-			$.binary_expression,
-			$.unary_expression,
-			$.function_call,
-			$.indexed_collection,
-			$.control_structure,
-		),
-
-		////////////////////////
-		// List Comprehension //
-		////////////////////////
-
-		list_comp_open: $ => token('{:'),
-
-		/**
-		 * list_comprehension
-		 * ------------------
-		 * Syntax:
-		 *   {: <body_expr>, <qualifier1>, <qualifier2>, ... }
-		 *
-		 * Examples:
-		 *   {: i * 2, i <- (1..10), i % 2 == 0 }
-		 */
-		list_comprehension: $ => prec(1, seq(
-			$.list_comp_open,
-			field('body', choice(
-				$._expression_sequence,
-				$._postfix              // Allow single expressions without semicolon
-			)),
-			',',
-			field('qualifiers', sepBy1(',', $.qualifier)),  // One or more qualifiers separated by commas
-			'}'
-		)),
-
-		qualifier: $ => choice(
-			$.generator,
-			$.guard,            // Conditional expressions to filter items
-			$.var_binding,      // Local variable bindings
-			$.side_effect,      // Code with side effects 
-			$.termination       // Termination condition for iteration
-		),
-
-		generator: $ => seq(
-			field('pattern', choice(
-				$.identifier,
-				$.collection  //  pattern matching like: [x,y] <- pairs
-			)),
-			'<-',
-			field('source', $._expression)
-		),
-
-		guard: $ => field('guard', $._postfix),
-
-		var_binding: $ => seq(
-			'var',
-			field('name', $.identifier),
-			'=',
-			field('value', $._expression)
-		),
-
-		side_effect: $ => seq(
-			'::',
-			field('expression', $._expression)
-		),
-
-		termination: $ => seq(
-			':while',
-			field('condition', $._expression)
-		),
-
-		////////////////////
-		//	Conditionals  //
-		////////////////////
-
-		control_structure: $ => prec(PRECEDENCE.controlstruct, choice(
-			$.if, $.while, $.for, $.forby, $.case, $.switch
-		)),
-
-		/**
-		 * if
-		 * --
-		 * Forms:
-		 *   if (expr) {true} {false?}
-		 *   if (expr, {true}, {false?})
-		 *   expr.if {true} ({false?})
-		 */
-		if: $ => choice(
-			// if (expr) trueFunc falseFunc
-			prec.right(seq(
-				field("name", "if"),
-				"(",
-				field("expression", $._postfix),
-				")",
-				field("true", $.function_block),
-				optional(field("false", $.function_block))
-			)),
-			// if (expr, trueFunc, falseFunc)
-			prec.right(seq(
-				field("name", "if"),
-				"(",
-				field("expression", $._postfix),
-				field("true", seq(",", $.function_block)),
-				optional(field("false", seq(",", $.function_block))),
-				")"
-			)),
-			// expr.if {true} ({false?})
-			seq(
-				prec.left(1, seq(
-					field("expression", $._postfix),
-					field("name", seq(".", "if"))
-				)),
-				choice(
-					field("true", $.function_block),
-					seq(
-						"(",
-						field("true", $.function_block),
-						optional(field("false", seq(",", $.function_block))),
-						")"
-					)
-				)
-			)
-		),
-
-		/**
-		 * while
-		 * -----
-		 * Forms:
-		 *   while ( {test}, {body} )
-		 *   testFunc.while {body}
-		 *   while {test} {body}
-		 */
-		while: $ => choice(
-			// while ( testFunc, bodyFunc )
-			prec.left(1, seq(
-				field("name", "while"),
-				"(",
-				field("test_func", $.function_block),
-				",",
-				field("body_func", $.function_block),
-				")"
-			)),
-			// testExpr.while { body }
-			seq(
-				field("expression", $._postfix),
-				field("name", ".while"),
-				field("body_func", $.function_block)
-			),
-			// while { test } { body }
-			seq(
-				field("name", "while"),
-				field("test_func", $.function_block),
-				field("body_func", $.function_block)
-			)
-		),
-
-
-		for: $ => choice(
-			// for ( start, end, {body} )
-			seq("for", "(", $._postfix, ",", $._postfix, ",", $.function_block, ")"),
-			// start.for ( end, {body} )
-			seq($.integer, ".for", "(", $.integer, ",", $.function_block, ")")
-		),
-		forby: $ => choice(
-			// forBy ( start, end, step, {body} )
-			seq(
-				field("name", "forBy"),
-				"(",
-				$.integer, ",", $.integer, ",", $.integer, ",", $.function_block,
-				")"
-			),
-			// start.forBy ( end, step, {body} )
-			seq(
-				$.integer,
-				field("name", ".forBy"),
-				"(",
-				$.integer, ",", $.integer, ",", $.function_block,
-				")"
-			)
-		),
-
-
-		case: $ => seq(
-			field("name", "case"),
-			repeat($.function_block),
-			";"
-		),
-
-		/**
-		 * switch
-		 * ------
-		 * Forms:
-		 *   switch ( expr, key, {body}, ... [, {default}] )
-		 *   switch { expr } key {body} ... [{default}]
-		 */
-		switch: $ => choice(
-			seq(
-				field("name", "switch"),
-				"(",
-				field("expr", $._postfix),
-				",",
-				sepBy(
-					",",
-					seq($._object, ",", $.function_block)
-				),
-				",",
-				seq($._object, ",", $.function_block),
-				optional(seq(",", $.function_block)),
-				")"
-			),
-			prec.right(seq(
-				field("name", "switch"),
-				$.code_block, // switch { expr }
-				repeat(seq($._postfix, $.function_block)),
-				seq($._postfix, $.function_block)
-			))
-		)
-	}
+  name: 'supercollider',
+
+  // ---------- Metadata / Tokens ----------
+  word: $ => $.identifier,
+  extras: $ => [/\s/, $.line_comment, $.block_comment],
+  externals: $ => [ $.block_comment, $._space_separator ],
+
+  // Optional supertypes (useful for queries)
+  // supertypes: $ => [ $._expression, $._object, $._primary ],
+
+  // ---------- Conflicts ----------
+  conflicts: $ => [
+    [$.switch],
+    [$._expression, $._object],
+    [$._primary, $.function_block],
+    [$._primary, $.collection],
+  ],
+
+  // ---------- Rules ----------
+  rules: {
+    // ===== Program =====
+    source_file: $ => repeat($._expression),
+
+    _expression: $ => choice(
+      $.class_def,
+      seq($._expression_statement, ";"),
+    ),
+
+    _expression_statement: $ => choice(
+      $.function_definition,
+      $.function_call,
+      $.binary_expression,
+      $.unary_expression,
+      $.keyword_message,
+      $._postfix,
+      $.variable_definition,
+      $.variable_definition_sequence,
+      $.return_statement
+    ),
+
+    // ===== Expression building blocks =====
+    _object: $ => choice(
+      $.association,
+      $.nil_conditional,
+      $.nil_guard,
+      $.nil_default,
+      $.function_block,
+      $.control_structure,
+      $.binary_expression,
+      $.unary_expression,
+      $.indexed_collection,
+      $.partial,
+      $.duplicated_statement,
+      $.keyword_message,
+      $._postfix
+    ),
+
+    _primary: $ => choice(
+      $.literal,
+      $.variable,
+      $.class,
+      $.collection,
+      $.list_comprehension,
+      $.code_block,
+      $.group
+    ),
+
+    partial: $ => prec.right(PRECEDENCE.partial, "_"),
+
+    duplicated_statement: $ => prec.left(PRECEDENCE.duplication, seq(
+      field("duplicated_object", $._object),
+      field("operator", "!"),
+      field("duplication_times", $._object)
+    )),
+
+    // ===== Functions / Calls / Chaining =====
+    function_definition: $ => prec.left(1, seq(
+      field("name", $.variable),
+      '=',
+      field("value", $.function_block)
+    )),
+
+    function_call: $ => seq(
+      choice(alias($.identifier, $.method_name), $.class),
+      "(", optional($.parameter_call_list), ")"
+    ),
+
+    method_call: $ => prec.right(seq(
+      ".",
+      field("name", alias($.identifier, $.method_name)),
+      optional(choice(
+        seq("(", optional($.parameter_call_list), ")"),
+        $.code_block
+      ))
+    )),
+
+    _postfix: $ => choice(
+      prec.left(PRECEDENCE.call, seq($._primary, repeat1($.method_call))),
+      $._primary
+    ),
+
+    instance_variable_setter_call: $ => prec.left(2, seq(
+      ".", field("name", alias($.identifier, $.method_name)), "_",
+      optional(seq("(", optional($.parameter_call_list), ")"))
+    )),
+
+    _expression_sequence: $ => seq(
+      repeat(prec.right(1, seq($._expression_statement, ";"))),
+      $._expression_statement,
+      optional(";")
+    ),
+
+    code_block: $ => seq(
+      '{',
+      optional($.parameter_list),
+      optional($._expression_sequence),
+      '}'
+    ),
+
+    group: $ => seq('(', $._expression_sequence, ')'),
+
+    function_block: $ => choice(
+      $.code_block,
+      prec.left(seq(alias($.identifier, $.method_name), $.code_block))
+    ),
+
+    parameter_list: $ => choice(
+      seq('arg', sepBy(',', $.argument), optional(alias($.variable_argument, $.argument)), ';'),
+      seq('|', sepBy(choice($._space_separator, ','), choice($.argument, alias($.variable_argument, $.argument))), '|')
+    ),
+
+    argument: $ => seq(
+      field("name", $.identifier),
+      field("value", optional(choice(
+        seq("=", choice($.literal, $.collection, $.code_block)),
+        $.code_block
+      )))
+    ),
+
+    variable_argument: $ => seq("...", field("name", $.identifier)),
+
+    parameter_call_list: $ => sepBy1(',', choice($.named_argument, $._object)),
+
+    named_argument: $ => seq(
+      field('name', choice($.symbol, $.identifier)),
+      ':',
+      field('value', $._object)
+    ),
+
+    // ===== Literals / Tokens =====
+    literal: $ => choice($.number, $.symbol, $.char, $.string, $.bool),
+
+    number: $ => choice($.integer, $.float, $.hexinteger, $.exponential),
+
+    integer: $ => /\d+/,
+    hexinteger: $ => /0x([a-fA-F\d])+/,
+    float: $ => /\d+\.\d+/,
+    exponential: $ => /-?\d+(\.\d+)?[eE]-?\d+/,
+
+    symbol: $ => choice(
+      prec.left(seq('\\', optional(choice($.identifier, /[0-9]+/, $.escape_sequence)))),
+      prec.left(seq("'", optional(token.immediate(/[^"'\\]+/)), "'")),
+    ),
+
+    char: $ => /\$./,
+
+    string: $ => repeat1(seq(
+      '"',
+      repeat(choice(
+        token.immediate(prec(PRECEDENCE.STRING, /[^"\\\n]+|\\\r?\n/)),
+        $.escape_sequence
+      )),
+      '"'
+    )),
+
+    bool: $ => choice("true", "false"),
+
+    escape_sequence: $ => token.immediate(seq(
+      '\\',
+      choice(
+        /[^xu0-7]/,
+        /[0-7]{1,3}/,
+        /x[0-9a-fA-F]{2}/,
+        /u[0-9a-fA-F]{4}/,
+        /u\{[0-9a-fA-F]+\}/
+      )
+    )),
+
+    identifier: $ => /[\p{L}_][\p{L}\p{N}_]*/u,
+
+    class: $ => prec(PRECEDENCE.class, field("name", /[A-Z][a-zA-Z\d_]*/)),
+
+    // ===== Variables / Bindings =====
+    variable: $ => choice(
+      $.environment_var,
+      $.classvar,
+      $.builtin_var,
+      $.instance_var
+    ),
+
+    builtin_var: $ => field("name", choice(
+      "inf", "nil",
+      "thisFunction", "thisFunctionDef", "thisMethod",
+      "thisProcess", "thisThread",
+      "currentEnvironment", "topEnvironment"
+    )),
+
+    local_var: $ => prec(PRECEDENCE.localvar, seq('var', field("name", $.identifier))),
+    instance_var: $ => seq(optional('var'), optional(choice("<", ">", "<>")), field("name", $.identifier)),
+    classvar: $ => seq('classvar', optional(choice("<", ">", "<>")), field("name", $.identifier)),
+    const: $ => seq('const', optional(choice("<", ">", "<>")), field("name", $.identifier)),
+
+    environment_var: $ => choice(
+      field("name", alias(/[a-z]/, $.identifier)),
+      field("name", alias(seq('~', $.identifier), $.identifier)),
+    ),
+
+    variable_name: $ => $.identifier,
+
+    variable_definition_sequence: $ => prec(PRECEDENCE.vardef_sequence, seq(
+      sepBy(",", choice($.variable_definition, $.variable)),
+      ",", choice($.variable_definition, $.variable)
+    )),
+
+    variable_definition: $ => prec(PRECEDENCE.vardef, seq(
+      field("name", $.variable),
+      "=",
+      field("value", $._object)
+    )),
+
+    return_statement: $ => prec.left(seq("^", choice($._object, $.function_call))),
+
+    // ===== Collections / Indexing =====
+    ref: $ => "`",
+
+    collection: $ => prec.left(seq(
+      choice(
+        $.arithmetic_series,
+        prec.left(seq(
+          optional(choice("#", $.ref)),
+          optional(optional(alias($.class, $.collection_type))),
+          "[", $._collection_sequence, "]"
+        )),
+        seq("(", $._paired_associative_sequence, ")")
+      )
+    )),
+
+    _collection_sequence: $ => seq(
+      sepBy1(",", choice($.associative_item, $._object)),
+      optional(",")
+    ),
+
+    _paired_associative_sequence: $ => seq(sepBy1(",", $.associative_item), optional(",")),
+
+    association: $ => prec(PRECEDENCE.association, seq(
+      prec.left($._object),
+      prec(PRECEDENCE.assign, "->"),
+      prec.right($._object)
+    )),
+
+    associative_item: $ => prec(PRECEDENCE.associative_item,
+      seq(choice(seq($.identifier, ":", alias($._object, $.item)), $.association))
+    ),
+
+    _indexable_object: $ => choice(
+      $._postfix,
+      prec.left(1, $.code_block),
+      $.control_structure
+    ),
+
+    indexed_collection: $ => seq($._indexable_object, repeat($._index), $._index),
+
+    index_subrange: $ => choice(
+      seq($._numeric_expression, ".."),
+      seq("..", $._numeric_expression),
+      seq($._numeric_expression, "..", $._numeric_expression),
+      seq($._numeric_expression, ",", $._numeric_expression, "..", $._numeric_expression),
+    ),
+
+    _index: $ => seq("[", field("index", choice($._numeric_expression, $.index_subrange)), "]"),
+
+    // ===== Arithmetic Series / Numeric Expr =====
+    arithmetic_series: $ => seq(
+      "(",
+      choice(
+        seq($._postfix, ",", $._postfix, "..", $._postfix), // (start, step..end)
+        seq("..", $._postfix),                              // (..end)
+        seq($._postfix, "..", $._postfix)                   // (start..end)
+      ),
+      ")"
+    ),
+
+    _numeric_expression: $ => choice(
+      $._postfix,
+      $.binary_expression,
+      $.unary_expression,
+      $.function_call,
+      $.indexed_collection,
+      $.control_structure
+    ),
+
+    // ===== Binary / Keyword / Unary =====
+    binary_expression: $ => prec.left(PRECEDENCE.BIN, seq(
+      field('left', $._postfix),
+      field('operator', choice(
+        '||', '&&', '|', '^', '&', '==', '!=', '<', '<=', '>', '>=',
+        '<<', '>>', '+', '-', '++', '+/+', '*', '/', '%', '**'
+      )),
+      field('right', $._postfix)
+    )),
+
+    keyword_message: $ => prec.left(PRECEDENCE.keyword_message, seq(
+      field('receiver', $._postfix),
+      field('selector', alias(/[a-zA-Z_]\w*:/, $.keyword_selector)),
+      field('argument', $._postfix)
+    )),
+
+    unary_expression: $ => prec.left(PRECEDENCE.unary, seq(
+      field("operator", choice('+', '-', ':')),
+      field("right", $._postfix)
+    )),
+
+    // ===== Nil-ops =====
+    nil_conditional: $ => prec.left(PRECEDENCE.BIN, choice(
+      seq(field('condition', $._postfix), '?', field('if_not_nil', $._postfix)),
+      seq(field('condition', $._postfix), '?', field('if_not_nil', $.code_block), field('if_nil', $.code_block))
+    )),
+
+    nil_guard: $ => prec.left(PRECEDENCE.BIN, seq(
+      field('value', $._postfix), '!?', field('action', choice($._postfix, $.code_block))
+    )),
+
+    nil_default: $ => prec.left(PRECEDENCE.BIN, seq(
+      field('value', $._postfix), '??', field('default', choice($._postfix, $.code_block))
+    )),
+
+    // ===== List Comprehension =====
+    list_comp_open: $ => token('{:'),
+
+    list_comprehension: $ => prec(1, seq(
+      $.list_comp_open,
+      field('body', choice($._expression_sequence, $._postfix)),
+      ',',
+      field('qualifiers', sepBy1(',', $.qualifier)),
+      '}'
+    )),
+
+    qualifier: $ => choice($.generator, $.guard, $.var_binding, $.side_effect, $.termination),
+
+    generator: $ => seq(
+      field('pattern', choice($.identifier, $.collection)),
+      '<-',
+      field('source', $._expression)
+    ),
+
+    guard: $ => field('guard', $._postfix),
+
+    var_binding: $ => seq('var', field('name', $.identifier), '=', field('value', $._expression)),
+
+    side_effect: $ => seq('::', field('expression', $._expression)),
+
+    termination: $ => seq(':while', field('condition', $._expression)),
+
+    // ===== Control Structures =====
+    control_structure: $ => prec(PRECEDENCE.controlstruct, choice(
+      $.if, $.while, $.for, $.forby, $.case, $.switch
+    )),
+
+    if: $ => choice(
+      prec.right(seq(
+        field("name", "if"), "(", field("expression", $._postfix), ")",
+        field("true", $.function_block),
+        optional(field("false", $.function_block))
+      )),
+      prec.right(seq(
+        field("name", "if"), "(", field("expression", $._postfix),
+        field("true", seq(",", $.function_block)),
+        optional(field("false", seq(",", $.function_block))), ")"
+      )),
+      seq(
+        prec.left(1, seq(field("expression", $._postfix), field("name", seq(".", "if")))),
+        choice(
+          field("true", $.function_block),
+          seq("(", field("true", $.function_block), optional(field("false", seq(",", $.function_block))), ")")
+        )
+      )
+    ),
+
+    while: $ => choice(
+      prec.left(1, seq(field("name", "while"), "(", field("test_func", $.function_block), ",", field("body_func", $.function_block), ")")),
+      seq(field("expression", $._postfix), field("name", ".while"), field("body_func", $.function_block)),
+      seq(field("name", "while"), field("test_func", $.function_block), field("body_func", $.function_block))
+    ),
+
+    for: $ => choice(
+      seq("for", "(", $._postfix, ",", $._postfix, ",", $.function_block, ")"),
+      seq($.integer, ".for", "(", $.integer, ",", $.function_block, ")")
+    ),
+
+    forby: $ => choice(
+      seq(field("name", "forBy"), "(", $.integer, ",", $.integer, ",", $.integer, ",", $.function_block, ")"),
+      seq($.integer, field("name", ".forBy"), "(", $.integer, ",", $.integer, ",", $.function_block, ")")
+    ),
+
+    case: $ => seq(field("name", "case"), repeat($.function_block), ";"),
+
+    switch: $ => choice(
+      seq(
+        field("name", "switch"), "(",
+        field("expr", $._postfix), ",",
+        sepBy(",", seq($._object, ",", $.function_block)), ",",
+        seq($._object, ",", $.function_block),
+        optional(seq(",", $.function_block)),
+        ")"
+      ),
+      prec.right(seq(field("name", "switch"), $.code_block, repeat(seq($._postfix, $.function_block)), seq($._postfix, $.function_block)))
+    ),
+
+    // ===== Classes =====
+    class_def: $ => prec(PRECEDENCE.class_def, seq(
+      optional("+"), $.class, optional(seq(":", alias($.class, $.parent_class))), "{",
+      repeat(choice(
+        // vars / var defs
+        seq(sepBy(",", choice(
+          choice(alias($.local_var, $.instance_var), $.instance_var, $.classvar),
+          seq(choice(alias($.local_var, $.instance_var), $.instance_var, $.classvar, $.const), "=", $._object)
+        )), ";"),
+        // instance methods
+        seq(alias($.identifier, $.instance_method_name), $.function_block),
+        // class methods
+        seq("*", alias($.identifier, $.class_method_name), $.function_block)
+      )),
+      "}"
+    )),
+
+    // ===== Comments =====
+    comment: $ => choice($.line_comment, $.block_comment),
+    line_comment: $ => prec(PRECEDENCE.comment, token(seq('//', /.*/))),
+
+    // ----- (Unused catalog helpers kept for reference) -----
+    _collection_types: $ => choice($._unordered_collection_types, $._ordered_collection_types),
+
+    _unordered_collection_types: $ => choice(
+      "Bag", "Dictionary", "Environment", "Event", "IdentityBag", "IdentityDictionary",
+      "IdentitySet", "LazyEnvir", "MultiLevelIdentityDictionary", "ObjectTable",
+      "Set", "TwoWayIdentityDictionary"
+    ),
+
+    _ordered_collection_types: $ => choice(
+      "Array", "Array2D", "ArrayedCollection", "DoubleArray", "FloatArray", "Int16Array",
+      "Int32Array", "Int8Array", "LinkedList", "List", "Order", "OrderedIdentitySet",
+      "Pair", "PriorityQueue", "RawArray", "SequenceableCollection", "Signal",
+      "SortedList", "SparseArray", "String", "SymbolArray"
+    ),
+  }
 });
+// End of grammar.js

--- a/grammar.js
+++ b/grammar.js
@@ -243,7 +243,8 @@ module.exports = grammar({
       $.environment_var,
       $.classvar,
       $.builtin_var,
-      $.instance_var
+      $.instance_var,
+      $.local_var // need this to capture it in highlights.scm
     ),
 
     builtin_var: $ => field("name", choice(

--- a/grammar.js
+++ b/grammar.js
@@ -147,9 +147,10 @@ module.exports = grammar({
 				),
 
 			),
+
 			// Instance method (chainable)
 			seq(
-				alias($._object, $.receiver),
+				field('receiver', $._primary),
 				repeat1(
 					choice(
 						$.method_call,

--- a/grammar.js
+++ b/grammar.js
@@ -124,20 +124,20 @@ module.exports = grammar({
       optional(seq("(", optional($.parameter_call_list), ")"))
     )),
 
-    _expression_sequence: $ => seq(
-      repeat(prec.right(1, seq($._expression_statement, ";"))),
+    expression_sequence: $ => seq(
+      repeat(seq($._expression_statement, ";")),
       $._expression_statement,
-      optional(";")
+      seq(optional(";"))
     ),
 
     code_block: $ => seq(
       '{',
       optional($.parameter_list),
-      optional($._expression_sequence),
+      optional($.expression_sequence),
       '}'
     ),
 
-    group: $ => seq('(', $._expression_sequence, ')'),
+    group: $ => seq('(', $.expression_sequence, ')'),
 
     function_block: $ => choice(
       $.code_block,
@@ -374,7 +374,7 @@ module.exports = grammar({
 
     list_comprehension: $ => prec(1, seq(
       $.list_comp_open,
-      field('body', choice($._expression_sequence, $._postfix)),
+      field('body', choice($.expression_sequence, $._postfix)),
       ',',
       field('qualifiers', sepBy1(',', $.qualifier)),
       '}'

--- a/grammar.js
+++ b/grammar.js
@@ -1,9 +1,9 @@
 const PRECEDENCE = {
 	comment: 1000,
 
-	call: 140,   // chains bind tighter than any binary op
-	BIN: 20,    // flat, left-associative binary tier
-	unary: 130,  // unary binds tighter than BIN (but below call)
+	call:  140,            // chains bind tighter than any binary op
+	BIN:   20,             // flat, left-associative binary tier
+	unary: 130,            // unary binds tighter than BIN (but below call)
 
 	association: 11,
 	associative_item: 10,
@@ -41,6 +41,7 @@ module.exports = grammar({
 		$._space_separator
 	],
 
+	// Inline declarations for optimization
 	//inline: $ => [$.keywords],
 
 	// The name of a token that will match keywords for the purpose of the keyword extraction optimization.
@@ -117,23 +118,23 @@ module.exports = grammar({
 			field("value", $.function_block)
 		)),
 
-		function_call: $ => prec.right(choice(
+		function_call: $ => prec.right(
+
 			choice(
 
 				// method prefixed: ar(SinOsc, 110)
 				seq(
 					choice(alias($.identifier, $.method_name), $.class),
-					seq("(", optional($.parameter_call_list), ")"),
+					"(", optional($.parameter_call_list), ")"
 				),
 
 				// implicit new on classes type SinOsc();
 				seq(
 					$.class,
 					seq("(", optional($.parameter_call_list), ")"),
-				),
+				)
 
 			),
-
 			// Instance method (chainable)
 			seq(
 				field('receiver', $._primary),
@@ -143,10 +144,9 @@ module.exports = grammar({
 						// This is already covered by the identifier rule, should it be more specific though?
 						$.instance_variable_setter_call,
 					)
-
 				)
 			)
-		)),
+		),
 
 		/**
 		 * _primary
@@ -230,19 +230,6 @@ module.exports = grammar({
 
 			)
 		),
-
-		// class_method_call: $ => prec.left(choice(
-		//	   // Class.method - class method
-		//	   prec.left(seq(
-		//		   ".",
-		//		   field("name", alias($.identifier, $.class_method_name)),
-		// optional(choice(
-
-		// seq("(", optional($.parameter_call_list), ")"), $._function_content)
-		//	   ))),
-		//	   // Class() - implicit .new
-		//	   seq("(", optional($.parameter_call_list), ")")
-		// )),
 
 		_expression_sequence: $ => seq(
 			repeat(prec.right(1, seq($._expression_statement, ";"))),
@@ -509,7 +496,7 @@ module.exports = grammar({
 									$.instance_var,
 									$.classvar
 								),
-								// variable definiton
+								// Variable definition
 								seq(
 									choice(
 										alias($.local_var, $.instance_var),
@@ -518,7 +505,7 @@ module.exports = grammar({
 										$.const
 									),
 									"=",
-									$._object,
+									$._object
 								),
 							)
 						),
@@ -609,6 +596,7 @@ module.exports = grammar({
 
 		// These are unused at the moment
 		_collection_types: $ => choice($._unordered_collection_types, $._ordered_collection_types),
+
 		_unordered_collection_types: $ => choice(
 			"Bag",
 			"Dictionary",
@@ -623,6 +611,7 @@ module.exports = grammar({
 			"Set",
 			"TwoWayIdentityDictionary"
 		),
+
 		_ordered_collection_types: $ => choice(
 			"Array",
 			"Array2D",
@@ -715,15 +704,6 @@ module.exports = grammar({
 			)),
 			field('right', $._postfix)
 		)),
-
-		// binary_expression: $ => prec.left(PRECEDENCE.BIN, seq(
-		// 	field('left', $._postfix),
-		// 	field('operator', choice(
-		// 		'||', '&&', '|', '^', '&', '==', '!=', '<', '<=', '>', '>=',
-		// 		'<<', '>>', '+', '-', '++', '+/+', '*', '/', '%', '**'
-		// 	)),
-		// 	field('right', $._postfix)
-		// )),
 
 		/**
 		 * unary_expression

--- a/grammar.js
+++ b/grammar.js
@@ -1,46 +1,36 @@
-
 const PRECEDENCE = {
   comment: 1000,
 
-  // expression tiers
   call: 140,           // postfix chains bind tighter than any binary op
   unary: 130,          // tighter than BIN, looser than call
   BIN: 20,             // flat, left-associative binary tier
   keyword_message: 19, // below BIN to preserve L→R evaluation
 
-  // misc
   association: 11,
   associative_item: 10,
   partial: 15,
   field: 13,
   duplication: 12,
-  controlstruct: 3,
   localvar: 4,
   vardef: 3,
   vardef_sequence: 2,
-  assign: 0,
   STRING: 2,
-  closure: -1,
   class_def: 1,
   class: 20
 };
 
-// Small combinators
 function sepBy1(sep, rule) { return seq(rule, repeat(seq(sep, rule))); }
 function sepBy(sep, rule) { return optional(sepBy1(sep, rule)); }
 
 module.exports = grammar({
   name: 'supercollider',
-
-  // ---------- Metadata / Tokens ----------
   word: $ => $.identifier,
   extras: $ => [/\s/, $.line_comment, $.block_comment],
   externals: $ => [$.block_comment, $._space_separator],
 
-  // Optional supertypes (useful for queries)
+  // Optional 
   // supertypes: $ => [ $._expression, $._object, $._primary ],
 
-  // ---------- Conflicts ----------
   conflicts: $ => [
     [$.switch],
     [$._expression, $._object],
@@ -48,9 +38,7 @@ module.exports = grammar({
     [$._primary, $.collection],
   ],
 
-  // ---------- Rules ----------
   rules: {
-    // ===== Program =====
     source_file: $ => repeat($._expression),
 
     _expression: $ => choice(
@@ -182,8 +170,6 @@ module.exports = grammar({
     // ===== Literals / Tokens =====
     literal: $ => choice($.number, $.symbol, $.char, $.string, $.bool),
 
-    number: $ => choice($.integer, $.float, $.hexinteger, $.exponential),
-
     integer: $ => /\d+/,
     hexinteger: $ => /0x([a-fA-F\d])+/,
     float: $ => /\d+\.\d+/,
@@ -244,7 +230,7 @@ module.exports = grammar({
       $.classvar,
       $.builtin_var,
       $.instance_var,
-      $.local_var // need this to capture it in highlights.scm
+      $.local_var
     ),
 
     builtin_var: $ => field("name", choice(
@@ -482,11 +468,10 @@ module.exports = grammar({
       "}"
     )),
 
-    // ===== Comments =====
     comment: $ => choice($.line_comment, $.block_comment),
     line_comment: $ => prec(PRECEDENCE.comment, token(seq('//', /.*/))),
 
-    // ----- (Unused catalog helpers kept for reference) -----
+    // Helper rules kept for reference
     _collection_types: $ => choice($._unordered_collection_types, $._ordered_collection_types),
 
     _unordered_collection_types: $ => choice(

--- a/grammar.js
+++ b/grammar.js
@@ -768,7 +768,7 @@ module.exports = grammar({
 				field('condition', $._postfix),
 				'?',
 				field('if_not_nil', $.code_block),
-				field('if_nil', optional($.code_block))
+				field('if_nil', $.code_block)
 			)
 		)),
 

--- a/grammar.js
+++ b/grammar.js
@@ -1,9 +1,9 @@
 const PRECEDENCE = {
 	comment: 1000,
 
-  	call: 140,   // chains bind tighter than any binary op
-  	BIN:  20,    // flat, left-associative binary tier
-  	unary: 130,  // unary binds tighter than BIN (but below call)
+	call: 140,   // chains bind tighter than any binary op
+	BIN: 20,    // flat, left-associative binary tier
+	unary: 130,  // unary binds tighter than BIN (but below call)
 
 	association: 11,
 	associative_item: 10,
@@ -103,7 +103,7 @@ module.exports = grammar({
 
 		duplicated_statement: $ => prec.left(PRECEDENCE.duplication, seq(
 			field("duplicated_object", $._object),
-			field("operator","!"),
+			field("operator", "!"),
 			field("duplication_times", $._object)
 		)),
 
@@ -147,7 +147,7 @@ module.exports = grammar({
 				)
 			)
 		)),
-		
+
 		/**
 		 * _primary
 		 * ----------
@@ -348,9 +348,9 @@ module.exports = grammar({
 		parameter_call_list: $ => sepBy1(',', choice($.named_argument, $._object)),
 
 		named_argument: $ => seq(
-		  field('name',  choice($.symbol, $.identifier)),
-		  ':',
-		  field('value', $._object)
+			field('name', choice($.symbol, $.identifier)),
+			':',
+			field('value', $._object)
 		),
 
 		///////////////////////
@@ -445,10 +445,10 @@ module.exports = grammar({
 		)),
 
 		local_var: $ => prec(PRECEDENCE.localvar, choice(
-			field("name", $.identifier), seq( 'var',  field("name", $.identifier)))
+			field("name", $.identifier), seq('var', field("name", $.identifier)))
 		),
 
-		instance_var: $=> seq( optional('var'), optional(choice("<", ">", "<>")), field("name", $.identifier)),
+		instance_var: $ => seq(optional('var'), optional(choice("<", ">", "<>")), field("name", $.identifier)),
 		classvar: $ => seq('classvar', optional(choice("<", ">", "<>")), field("name", $.identifier)),
 		const: $ => seq('const', optional(choice("<", ">", "<>")), field("name", $.identifier)),
 
@@ -584,7 +584,7 @@ module.exports = grammar({
 		associative_item: $ => prec(PRECEDENCE.associative_item,
 			seq(
 				choice(
-					seq($.identifier, ":",	alias($._object,  $.item)),
+					seq($.identifier, ":", alias($._object, $.item)),
 					$.association
 				)
 			)
@@ -766,7 +766,7 @@ module.exports = grammar({
 			prec.right(seq(
 				field("name", "if"),
 				"(",
-				field("expression", $._postfix),	
+				field("expression", $._postfix),
 				field("true", seq(",", $.function_block)),
 				optional(field("false", seq(",", $.function_block))),
 				")"

--- a/grammar.js
+++ b/grammar.js
@@ -21,7 +21,6 @@ const PRECEDENCE = {
 	range: 1,
 	indexing: 1,
 	assign: 0,
-	selectorBinary: 100,
 	controlstruct: 3,
 	localvar: 4,
 	vardef: 3,
@@ -618,9 +617,6 @@ module.exports = grammar({
 		binary_expression: $ => {
 			const table = [
 
-				// "Selector as binary operator"
-				// @TODO
-				[PRECEDENCE.selectorBinary, alias(/(r#)?[a-zA-Zα-ωΑ-Ωµ_][a-zA-Zα-ωΑ-Ωµ\d_]*:/, $.method_name)],
 
 				// "Regular" binary operators
 				[PRECEDENCE.and, '&&'],

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,116 +1,113 @@
-; highlights.scm
-; See this for full list: https://github.com/nvim-treesitter/nvim-treesitter/blob/master/CONTRIBUTING.md
-
+; =========================
 ; Comments
+; =========================
 (line_comment) @comment @spell
 (block_comment) @comment @spell
 
-; Argument definition
-(argument 
-  name: (identifier) @variable.parameter)
-
-; Variable argument
-[ "..." ] @variable.parameter
-
-; Variables
-(local_var 
-  name: (identifier) @variable)
-
-(environment_var 
-  name:(identifier) @variable.builtin)
-
-(builtin_var) @constant.builtin
-
-; Functions
-(named_argument
-  name: (identifier) @variable.parameter)
-
-; Methods
-(method_call
-  name: (method_name) @function.method.call)
-
-(method_name) @function.method.call
-
-; Collections
-(associative_item
-  (identifier) @property)
-
-; Classes
-(class) @type
+; =========================
+; Definitions / Types
+; =========================
+(class (name: (_) @type))
 (parent_class) @type
+(instance_method_name) @method
+(class_method_name)    @method
 
-(instance_method_name) @function.method
-(class_method_name) @function.method
+; =========================
+; Calls
+; =========================
+; Bare function/class calls: foo(...), SinOsc(...)
+(function_call (method_name) @function.call)
+(function_call (class)       @constructor)
 
+; Instance method calls: obj.foo(...)
+(method_call name: (method_name) @method.call)
+
+; Keyword messages: coll collect: {...}
+(keyword_message
+  (selector: (keyword_selector) @method.call))
+
+; =========================
+; Parameters / Arguments
+; =========================
+(parameter_list (argument (identifier) @variable.parameter))
+(parameter_list (argument (variable_argument (identifier) @variable.parameter)))
+(named_argument (name: (identifier) @variable.parameter))
+(named_argument (name: (symbol)     @variable.parameter))
+
+; =========================
+; Variables & Bindings
+; =========================
+(local_var       (identifier) @variable)
+(instance_var    (identifier) @variable)
+(classvar        (identifier) @variable)
+(const           (identifier) @constant)
+(builtin_var)                      @constant.builtin
+(environment_var (identifier)      @variable.builtin)
+
+; =========================
 ; Literals
-(bool) @boolean
-(number) @number
-(float) @number.float
-(string) @string
+; (use leaf kinds to avoid double-highlighting)
+; =========================
+(integer)      @number
+(hexinteger)   @number
+(float)        @number.float
+(exponential)  @number.float
+(pi_literal)   @number.float
+(accidental)   @number
+(string)       @string
 (escape_sequence) @string.escape
-(symbol) @string.special.symbol
+(symbol)       @string.special.symbol
+(char)         @character
+(bool)         @boolean
 
-; Conditionals
-[
-  "if"
-  "while"
-  "case"
-  "switch"
-  "?"
-  "!?"
-  "??"
-] @keyword.conditional
+; =========================
+; Operators / Pairs
+; =========================
+(binary_expression (operator) @operator)
+(unary_expression  (operator) @operator)
 
-; Iterations
-[ "for" "forBy" ] @keyword.repeat
+; nil-ops: highlight only the operator tokens
+(nil_conditional "?") @keyword.conditional
+(nil_guard      "!?") @keyword.conditional
+(nil_default    "??") @keyword.conditional
 
-; Duplication operator
-[ "!" ] @keyword.repeat
+; association pairs
+(association "->") @operator
 
-; Arithmetic series operator
-[ ".." ] @operator
+; duplication (x ! n)
+(duplicated_statement "!" @operator)
 
-; Operators
-[
-  "&&"
-  "||"
-  "&"
-  "|"
-  "^"
-  "=="
-  "!="
-  "<"
-  "<="
-  ">"
-  ">="
-  "<<"
-  ">>"
-  "+"
-  "-"
-  "*"
-  "/"
-  "%"
-  "="
-  "@"
-  "|@|"
-  "@@"
-  "@|@"
-  "++"
-  "+/+"
-] @operator
+; dotdot range
+[".."] @operator
 
-; Keywords
-[
-  "arg"
-  "classvar"
-  "const"
-  ; "super"
-  ; "this"
-  "var"
-] @keyword
+; adverb after binop: .foo / .3 / .(expr)
+(adverb "." @operator)
 
-; Brackets
+; =========================
+; Collections / Properties
+; =========================
+(associative_item (identifier) @property)
+(associative_item (symbol)     @property)
+
+; =========================
+; Control keywords (token-only)
+; =========================
+["if" "while" "case" "switch"] @keyword.conditional
+["for" "forBy"]                @keyword.repeat
+
+; return ^
+(return_statement "^") @keyword
+
+; =========================
+; List comprehensions / Generators
+; =========================
+(list_comp_open)  @punctuation.bracket   ; '{:'
+(generator "<-")  @operator
+(termination ":while") @keyword.conditional
+(side_effect "::")     @operator
+
+; =========================
+; Punctuation
+; =========================
 [ "(" ")" "[" "]" "{" "}" "|" ] @punctuation.bracket
-
-; Delimeters
-[ ";" "." "," ] @punctuation.delimiter
+[ ";" "," ":" "." ]             @punctuation.delimiter

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -7,7 +7,7 @@
 ; =========================
 ; Definitions / Types
 ; =========================
-(class (name: (_) @type))
+(class)        @type ; we can capture the whole node here
 (parent_class) @type
 (instance_method_name) @method
 (class_method_name)    @method
@@ -23,20 +23,21 @@
 (method_call name: (method_name) @method.call)
 
 ; Keyword messages: coll collect: {...}
-(keyword_message
-  (selector: (keyword_selector) @method.call))
+(keyword_message 
+  selector: (keyword_selector) @method.call) ; fix typo
 
 ; =========================
 ; Parameters / Arguments
 ; =========================
-(parameter_list (argument (identifier) @variable.parameter))
-(parameter_list (argument (variable_argument (identifier) @variable.parameter)))
-(named_argument (name: (identifier) @variable.parameter))
-(named_argument (name: (symbol)     @variable.parameter))
+(parameter_list "arg" @keyword) ; capture the 'arg' keyword
+(parameter_list (argument (identifier) @variable.parameter)) ; variable_argument is aliased to argument in grammar.js
+(named_argument name: (identifier) @variable.parameter) ; fix typo
+(named_argument name: (symbol)     @variable.parameter) ; fix typo
 
 ; =========================
 ; Variables & Bindings
 ; =========================
+[ "var" "classvar" "const"] @keyword ; capture the variable keywords
 (local_var       (identifier) @variable)
 (instance_var    (identifier) @variable)
 (classvar        (identifier) @variable)
@@ -63,8 +64,14 @@
 ; =========================
 ; Operators / Pairs
 ; =========================
-(binary_expression (operator) @operator)
-(unary_expression  (operator) @operator)
+; operator is a field with unamed nodes so we need to capture them explicitly
+(binary_expression 
+  operator: [
+    "||" "&&" "|" "^" "&" "==" "!=" "<" "<=" ">" ">="
+    "<<" ">>" "+" "-" "++" "+/+" "*" "/" "%" "**"
+  ] @operator)
+(unary_expression  operator: ["+" "-" ":"] @operator)
+["="] @operator
 
 ; nil-ops: highlight only the operator tokens
 (nil_conditional "?") @keyword.conditional
@@ -80,14 +87,15 @@
 ; dotdot range
 [".."] @operator
 
+; is this used ?
 ; adverb after binop: .foo / .3 / .(expr)
-(adverb "." @operator)
+; (adverb "." @operator)
 
 ; =========================
 ; Collections / Properties
 ; =========================
 (associative_item (identifier) @property)
-(associative_item (symbol)     @property)
+(associative_item ":"          @property) ; no 'symbol' node in associative_item
 
 ; =========================
 ; Control keywords (token-only)


### PR DESCRIPTION
## Fix method-call precedence, unify binary operators, and implement list comprehensions

### Summary

- **Operators:** All binary operators now use consistent left-to-right evaluation
- **Method chains bind tightly:** New `_primary`/`_postfix` rules ensure method calls attach to the right expression
- **List comprehensions:** Full support for `{:` syntax with generators, guards, bindings, side effects, and termination
- **Fixed named arguments:** `parameter: value` syntax now correctly stores values
- **Control flow:** `if`, `while`, `switch` handle expressions consistently
- **Block syntax:** Code blocks use `{ … }`, parentheses use `( … )`
- Added dedicated rules for nil-check operators

Up to discussion:

- ~~**Keyword messages:** Separated from binary operators into dedicated rule for `[1,2,3] collect: {...}` syntax~~

### Motivation

Problems fixed:

- No support for list comprehensions (`{: x*2, x <- (1..10)}`)
- `identifier:` patterns conflated with binary operators
- `{ … }` and `(…)` confusion
- `.midiratio` binding to entire expressions instead of grouped RHS
- `curve: -1` stored incorrectly under `name:` instead of `value:`
- Operator precedence tiers that don't exist in sclang

### This branch is organized into small commits:

Some changes span over different (non-)consecutive commits. 
But it is easy to distinguish **logical changes**:

1. Introduce block/group distinction (1)
2. Add _primary/_postfix hierarchy (2-3)
3. Flatten binary precedence (4-6)
4. Fix argument handling (7)
5. Update control structures (10)
6. Clean up unused code (8-9, 11-13)
7. Add keyword messages (14-15)
8. Add list comprehensions (15-18)
9. reorganized `_expression_statement` and `_object` (21)
10. Dedicated rules for nil-check operators (22)


### List comprehensions

List comprehension syntax:

```supercollider
{: body, qualifier, qualifier, ... }
```

Supported qualifiers:

- **Generators:** `x <- (1..10)`
- **Guards:** `x.odd`
- **Variable bindings:** `var z = x*x`
- **Side effects:** `:: x.postln`
- **Termination:** `:while x < 100`

### Keyword messages

Separated `identifier:` patterns from binary operators:

```javascript
keyword_message: $ => prec.left(PRECEDENCE.keyword_message, seq(
  field('receiver', $._postfix),
  field('selector', alias(/[a-zA-Z_]\w*:/, $.keyword_selector)),
  field('argument', $._postfix)
))
```

This handles `[1,2,3] select: {|x| x > 1}` as a distinct syntactic form.

### Blocks & grouping

- `code_block: '{' parameter_list? expression_sequence? '}'`
- `group: '(' expression ')'`
- `function_block` now uses `code_block` directly

### Chains > binops

- Introduce `_primary` (atoms) and `_postfix` (primary + chain)
- Method chains parse left-associatively with high `CALL` precedence
- `function_call` receivers restricted to `_primary`

### Flat binary operators (left-to-right)

All symbolic binary operators now share one `BIN` tier:

```javascript
binary_expression: $ => prec.left(PRECEDENCE.BIN, seq(
  field('left',  $._postfix),
  field('operator', choice(
    '||','&&','|','^','&','==','!=','<','<=','>','>=',
    '<<','>>','+','-','++','+/+','*','/','%','**'
  )),
  field('right', $._postfix)
))
```

### Arguments

- Drop `argument_calls`/`unnamed_argument`
- `named_argument: name ':' value` with RHS under `value:`

### Control structures

- `if`, `while`, `switch` expressions take `_postfix` (chains bind)

## Before / After

### List comprehensions

- **Before:** Not supported
- **After:** Supported

```supercollider
{: [x,y], x <- (1..5), y <- (1..x), (x+y).isPrime }
```

### Keyword messages

- Dedicated AST node with receiver/selector/argument fields

### `.midiratio` binding

- **Before:** Could attach to `\freq.kr(440) * (…)` as a whole
- **After:** Attaches to grouped RHS term:

```
\freq.kr(440) * (Env.perc(...).ar * 48).midiratio
                 └────── group ────────┘└postfix┘
```

### Named argument

- **Before:** `curve: -1` created two `name:` fields
- **After:** `name: curve`, `value: -1`

## Testing

Needs tests for:

- List comprehension qualifiers
- Keyword message vs binary operator disambiguation
- Postfix vs group binding
- Named args with negative values
- Left-to-right operator evaluation
