### PR TITLE
Readme, update nvim-treesitter setup: get_parser_configs are no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Add this to your nvim config (change path in `url` to that of the tree sitter su
 
 ```lua
 -- tree-sitter-supercollider
-local parser_config = require "nvim-treesitter.parsers".get_parser_configs()
-parser_config.supercollider = {
+local parsers = require "nvim-treesitter.parsers"
+parsers.supercollider = {
 	install_info = {
 		-- url = "~/code/tree-sitter-supercollider",
 		url = "https://github.com/madskjeldgaard/tree-sitter-supercollider",


### PR DESCRIPTION
I think simply setting `parsers.supercollider` is what we want; get_parser_configs() doesn't exist (any more?).
 
The reason I'm opening this is a draft is that I still haven't yet got the grammar to work on my end, which is likely for unrelated reasons... but I also can't yet verify that the proposed changes do in fact work.