### PR TITLE
Fix: accept single-letter identifiers as named-argument names

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -249,10 +249,21 @@ export default grammar({
 
 		// function call is added here to allow things like Array() in params
 		unnamed_argument: $ => choice($.function_call, $._object),
-		named_argument: $ => prec.left(10, seq(
-			field("name", choice($.symbol, $.identifier)),
-			choice('=', ':'),
-			field("value", choice($.function_call, $._object))
+		named_argument: $ => prec.left(10, choice(
+			seq(
+				field("name", choice($.symbol, $.identifier)),
+				choice('=', ':'),
+				field("value", choice($.function_call, $._object))
+			),
+			// Single-letter names lex as environment_var's /[a-z]/ token, so
+			// they need their own branch: f.value(2, c: 3). Restricted to the
+			// ':' form so assignments to interpreter globals in argument
+			// position (f(n = x)) keep parsing as unnamed arguments.
+			seq(
+				field("name", alias(/[a-z]/, $.identifier)),
+				':',
+				field("value", choice($.function_call, $._object))
+			)
 		)),
 
 		///////////////////////

--- a/test/corpus/functions.txt
+++ b/test/corpus/functions.txt
@@ -800,3 +800,65 @@ Something { } { };
     (parameter_call_list 
       (function_block)
       (function_block)))))
+
+================================================================================
+named arguments with single-letter names
+================================================================================
+
+f.value(2, c: 3, b: 4);
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_call
+    (variable
+      (environment_var
+        (identifier)))
+    (identifier)
+    (parameter_call_list
+      (unnamed_argument
+        (literal
+          (number
+            (integer))))
+      (named_argument
+        (identifier)
+        (literal
+          (number
+            (integer))))
+      (named_argument
+        (identifier)
+        (literal
+          (number
+            (integer)))))))
+
+================================================================================
+assignment to interpreter global in argument position stays unnamed
+================================================================================
+
+s.sendMsg("/s_new", "test", n = s.nextNodeID);
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (function_call
+    (variable
+      (environment_var
+        (identifier)))
+    (identifier)
+    (parameter_call_list
+      (unnamed_argument
+        (literal
+          (string)))
+      (unnamed_argument
+        (literal
+          (string)))
+      (unnamed_argument
+        (function_call
+          (binary_expression
+            (variable
+              (environment_var
+                (identifier)))
+            (variable
+              (environment_var
+                (identifier))))
+          (identifier))))))


### PR DESCRIPTION
Single-letter identifiers currently can't be used as named-argument names — f.value(2, c: 3) fails to parse.

Cause: a–z lex as environment_var's dedicated /[a-z]/ token (interpreter globals). In the argument position, the lexer hands out that token, which named_argument doesn't accept — so the name errors and the rest of the call misparses.

Fix: add a named_argument branch accepting the single-letter token, restricted to the ':' form only. The restriction matters: with = included, assignments to interpreter globals in argument position — e.g. s.sendMsg("/s_new", "test", n = s.nextNodeID), a common idiom in the help docs — would be captured as named arguments and break. Corpus tests cover both directions.

This is valid sclang per the reference grammar (lang11d, keyarglist1/keyarg), verified against the interpreter:

supercollider
f = { |a, b, c| [a, b, c] };
f.value(2, c: 3);   // -> [ 2, nil, 3 ]