### PR TITLE
Fix: array elements are expression sequences (semicolons in collections)

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -451,9 +451,13 @@ export default grammar({
 			)
 		)),
 
+		// Array elements are expression sequences per sclang's grammar
+		// (lang11d: arrayelems1 elements are exprseq, and exprseq is
+		// `exprn optsemi`), so `[a; b, c]` and a trailing `;` inside an
+		// element (`[x, foo(y);]`) are legal sclang.
 		_collection_sequence: $ => seq(sepBy1(",", choice(
 			$.associative_item,
-			$._object
+			seq($._object, repeat(seq(";", $._object)), optional(";"))
 		)), optional(",")),
 
 		_paired_associative_sequence: $ => seq(sepBy1(",", $.associative_item), optional(",")),

--- a/test/corpus/collections.txt
+++ b/test/corpus/collections.txt
@@ -668,3 +668,39 @@ a = Set[1, 2, 3];
       (literal
         (number
           (integer ))))))
+
+================================================================================
+expression sequence in array elements with trailing semicolon
+================================================================================
+
+x = [Prand([nil, Pseq([24, 31]);]), 5];
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (variable_definition
+    (variable
+      (environment_var
+        (identifier)))
+    (collection
+      (function_call
+        (class)
+        (parameter_call_list
+          (unnamed_argument
+            (collection
+              (variable
+                (builtin_var))
+              (function_call
+                (class)
+                (parameter_call_list
+                  (unnamed_argument
+                    (collection
+                      (literal
+                        (number
+                          (integer)))
+                      (literal
+                        (number
+                          (integer)))))))))))
+      (literal
+        (number
+          (integer))))))


### PR DESCRIPTION
Semicolons inside array literals fail to parse — [1, 2; 3, 4] and trailing-semicolon elements like [x, foo(y);] both error, though both are legal sclang.

Reference: in lang11d, arrayelems1 elements are exprseq, and exprseq : exprn optsemi — so each array element may be a semicolon-separated expression sequence (valued at its last expression), optionally with a trailing ;. Verified against the interpreter:

supercollider
[1, 2; 3, 4];        // -> [ 1, 3, 4 ]
[nil, 100.rand;];    // -> [ nil, 61 ] — trailing ; accepted

The trailing-semicolon form appears in the official help docs (Streams-Patterns-Events3).

Fix: extend _collection_sequence elements from $._object to seq($._object, repeat(seq(";", $._object)), optional(";")) — mirroring what unnamed_argument already does for argument lists, where this has worked all along. Corpus test included; plain arrays, associative items, and trailing commas are unchanged.